### PR TITLE
Fixing 'EntityAlreadyExists' error on price cache

### DIFF
--- a/app/utilities/cache.py
+++ b/app/utilities/cache.py
@@ -4,7 +4,7 @@ import os
 import requests
 
 from datetime import datetime, timedelta
-from azure.data.tables import TableServiceClient
+from azure.data.tables import TableServiceClient, UpdateMode
 
 table_service = TableServiceClient.from_connection_string(
     conn_str=os.environ["AzureWebJobsStorage"]
@@ -55,7 +55,7 @@ def get_price(currency, vm):
             "MonthlyPrice": monthlyPrice,
         }
 
-        cache_table_client.create_entity(entity=cacheEntry)
+        cache_table_client.upsert_entity(entity=cacheEntry, mode=UpdateMode.REPLACE)
 
         logging.info(f"Creating price cache entry {lookup_string}")
     


### PR DESCRIPTION
Issue caused by trying to insert a new entry into the `pricecache` table after old entries have expired.

Change to using upsert instead of insert to deal with expired pricecache entries properly

<img width="441" alt="image" src="https://github.com/sg3-141-592/AzStartStop/assets/5122866/5b768451-1105-49e8-94ed-f839f5880970">
