### PR TITLE
Adding minimum length for start/stop window

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -68,7 +68,7 @@ export default {
       signUpDisabled: false,
       signedUp: false,
       settingsView: false,
-      showSignUps: true
+      showSignUps: false
     };
   },
 };

--- a/frontend/src/components/SetSchedule.vue
+++ b/frontend/src/components/SetSchedule.vue
@@ -170,6 +170,8 @@ export default {
           if (newVal.startTime && newVal.stopTime) {
             if (timeToDate(newVal.startTime) >= timeToDate(newVal.stopTime)) {
               errors.push("Start time should be before stop time");
+            } else if (timeToDate(newVal.stopTime) - timeToDate(newVal.startTime) < 1800000) {
+              errors.push("Schedule should be at least 30 minutes long")
             }
           }
         }

--- a/frontend/src/components/UpdateSettings.vue
+++ b/frontend/src/components/UpdateSettings.vue
@@ -1,5 +1,5 @@
 <template>
-    <h1 class="title">Settings</h1><p>Release 1.1-preview, September 2023</p>
+    <h1 class="title">Settings</h1><p>Release 1.2-preview, September 2023</p>
     <hr />
     <div class="field">
         <label class="label">Timezone</label>


### PR DESCRIPTION
- Add a check that start/stop windows are at a minimum 30 minutes long

<img width="503" alt="image" src="https://github.com/sg3-141-592/AzStartStop/assets/5122866/208fcd93-739f-47df-9306-c79285209b2b">

- Start and stop multiple VMs asynchronously
- Increases the start/stop trigger to run every 5 minutes