### PR TITLE
Fix for wrong currency displayed in estimated cost for next month

### DIFF
--- a/app/function_get.py
+++ b/app/function_get.py
@@ -119,7 +119,7 @@ def get_vms(req: func.HttpRequest) -> func.HttpResponse:
                 "name": vm.name,
                 "sku": vm.hardware_profile.vm_size,
                 "monthlyCost": monthlyPrice,
-                "estimatedCost": None,
+                "monthlyCostCurrency": currency,
                 "actualCost": actualCost,
                 "actualCostCurrency": actualCostCurrency,
                 "resourceGroup": resourceGroup

--- a/frontend/src/components/SubscriptionSummary.vue
+++ b/frontend/src/components/SubscriptionSummary.vue
@@ -27,9 +27,9 @@
         <div v-if="expanded === true" class="columns">
             <div class="column">
                 <h2 class="has-text-white is-underlined">VM Spend</h2>
-                <a class="has-text-white has-text-weight-bold is-size-4">{{ calcVMSpend() == 0 ? "--" : currencyText(calcVMSpend()) }}</a><a
+                <a class="has-text-white has-text-weight-bold is-size-4">{{ calcVMSpend() == 0 ? "--" : currencyText(calcVMSpend(), this.currency) }}</a><a
                     class="has-text-white"> last month</a>
-                <p><a class="has-text-white has-text-weight-bold is-size-4">{{ currencyText(calcEstSpend()) }}</a><a
+                <p><a class="has-text-white has-text-weight-bold is-size-4">{{ currencyText(calcEstSpend(), this.monthlyCurrency) }}</a><a
                         class="has-text-white"> est. next month</a></p>
                 <!-- <p class="has-text-white"><i class="fa-solid fa-arrow-trend-down"></i> $1,092 month</p> -->
             </div>
@@ -54,9 +54,13 @@ export default {
     props: ['vms'],
     watch: {
         vms: function(newVms) {
-            // Try and get the currency
+            // Try and get the bill currency
             if(newVms != null && newVms.length > 0) {
                 this.currency = newVms[0].actualCostCurrency
+            }
+            // Try and get the estimate currency
+            if(newVms != null && newVms.length > 0) {
+                this.monthlyCurrency = newVms[0].monthlyCostCurrency
             }
         }
     },
@@ -102,7 +106,8 @@ export default {
     data() {
         return {
             expanded: false,
-            currency: "usd"
+            currency: null,
+            monthlyCurrency: null,
         }
     }
 }


### PR DESCRIPTION
Estimated cost for next month now uses currency from the settings.

<img width="550" alt="image" src="https://github.com/sg3-141-592/AzStartStop/assets/5122866/04d43a0b-71e5-41c1-a204-e94690c0d7af">
