### PR TITLE
Adding deployment copying behaviour

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,4 +1,3 @@
-adal==1.2.7
 aiofile==3.8.1
 azure-common==1.1.28
 azure-core==1.26.1
@@ -11,17 +10,5 @@ azure-mgmt-costmanagement==3.0.0
 azure-mgmt-resource==21.2.1
 azure-mgmt-subscription==3.1.1
 azure-storage-blob==12.14.1
-caio==0.9.12
 croniter==1.3.8
-isodate==0.6.1
-msal==1.20.0
-msal-extensions==1.0.0
-msrest==0.7.1
-msrestazure==0.6.4
-multidict==6.0.4
-oauthlib==3.2.2
-portalocker==2.6.0
-PyJWT==2.6.0
 pytz==2023.3
-requests-oauthlib==1.3.1
-yarl==1.9.2

--- a/app/utilities/__init__.py
+++ b/app/utilities/__init__.py
@@ -3,6 +3,7 @@ from .log import log_vm_event
 from .azure import get_subscriptions
 from .settings import get_setting, set_setting, CURRENCIES
 from .cache import get_price
+from .update import copy_url_to_blob, DEPLOYMENT_URL
 
 STARTSCHEDULETAG = "vm-start-schedule"
 STOPSCHEDULETAG = "vm-stop-schedule"

--- a/app/utilities/settings.py
+++ b/app/utilities/settings.py
@@ -25,6 +25,8 @@ def get_setting(name):
     return None
 
 # If they don't exist create default settings
+if not get_setting("VersionEtag"):
+    set_setting("VersionEtag", "\"0x8DBBADD98158CBA\"")
 if not get_setting("Timezone"):
     set_setting("Timezone", "UTC")
 if not get_setting("Currency"):

--- a/app/utilities/update.py
+++ b/app/utilities/update.py
@@ -1,0 +1,25 @@
+import os
+from azure.storage.blob import BlobServiceClient
+import requests
+
+DEPLOYMENT_URL = "https://startstopvmresources.compactcloud.co.uk/releases/az-start-stop-latest.squashfs"
+
+def copy_url_to_blob() -> None:
+    # Download the file from the URL
+    response = requests.get(DEPLOYMENT_URL)
+    data = response.content
+
+    # Create a BlobServiceClient object using the connection string
+    blob_service_client = BlobServiceClient.from_connection_string(
+        conn_str=os.environ["AzureWebJobsStorage"]
+    )
+
+    container_client = blob_service_client.get_container_client("deployment")
+    if not container_client.exists():
+        container_client.create_container()
+
+    # Get a BlobClient object for the container and blob
+    blob_client = container_client.get_blob_client("az-start-stop-latest.squashfs")
+
+    # Upload the file to the blob
+    blob_client.upload_blob(data, overwrite=True)

--- a/copyDeployment.json
+++ b/copyDeployment.json
@@ -1,0 +1,100 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "storageAccountName": {
+            "type": "string"
+        },
+        "storageAccountContainer": {
+            "type": "string"
+        },
+        "downloadUrl": {
+            "type": "string"
+        },
+        "targetBlobFilename": {
+            "type": "string"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Storage/storageAccounts",
+            "apiVersion": "2021-02-01",
+            "name": "[parameters('storageAccountName')]",
+            "sku": {
+                "name": "Standard_LRS"
+            },
+            "kind": "StorageV2",
+            "location": "[resourceGroup().location]",
+            "properties": {
+                "allowBlobPublicAccess": false,
+                "minimumTlsVersion": "TLS1_2"
+            }
+        },
+        {
+            "name": "[concat(parameters('storageAccountName'), '/default/', parameters('storageAccountContainer'))]",
+            "type": "Microsoft.Storage/storageAccounts/blobServices/containers",
+            "apiVersion": "2023-01-01",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]"
+            ],
+            "properties": {
+                "publicAccess": "None"
+            }
+        },
+        {
+            "type": "Microsoft.Resources/deploymentScripts",
+            "apiVersion": "2020-10-01",
+            "name": "copyAzStartStopDeployment",
+            "location": "[resourceGroup().location]",
+            "dependsOn": [
+                "[resourceId('Microsoft.Storage/storageAccounts/blobServices/containers', parameters('storageAccountName'), 'default', parameters('storageAccountContainer'))]"
+            ],
+            "kind": "AzurePowerShell",
+            "properties": {
+                "azPowerShellVersion": "8.3",
+                "timeout": "PT10M",
+                "retentionInterval": "P1D",
+                "arguments": "[format(' -storageAccountName {0} -storageAccountKey {1} -storageAccountContainer {2} -downloadUrl {3} -targetBlobFilename {4}', parameters('storageAccountName'), listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value, parameters('storageAccountContainer'), parameters('downloadUrl'), parameters('targetBlobFilename'))]",
+                "cleanupPreference": "Always",
+                "scriptContent": "
+                    param(
+                        [string] [Parameter(Mandatory=$true)] $storageAccountName,
+                        [string] [Parameter(Mandatory=$true)] $storageAccountKey,
+                        [string] [Parameter(Mandatory=$true)] $storageAccountContainer,
+                        [string] [Parameter(Mandatory=$true)] $downloadUrl,
+                        [string] [Parameter(Mandatory=$true)] $targetBlobFilename
+                    )
+
+                    $storageContext = New-AzStorageContext -StorageAccountName $storageAccountName -StorageAccountKey $storageAccountKey
+
+                    $WebClient = New-Object System.Net.WebClient
+                    $content = $WebClient.DownloadFile($downloadUrl, '/tmp/download_file')
+                    $WebClient.Dispose()
+
+                    Set-AzStorageBlobContent -Container $storageAccountContainer -Blob $targetBlobFilename -Context $storageContext -File '/tmp/download_file' -Force
+
+                    $DeploymentScriptOutputs = @{}
+
+                    $DeploymentScriptOutputs['deploymentSasToken'] = New-AzStorageBlobSASToken -Context $storageContext `
+                        -Container $storageAccountContainer `
+                        -Blob $targetBlobFilename `
+                        -Permission r `
+                        -ExpiryTime (Get-Date).AddYears(10) `
+                        -FullUri
+                "
+            }
+        }
+    ],
+    "outputs": {
+        "deploymentSasToken": {
+            "type": "string",
+            "value": "[reference('copyAzStartStopDeployment').outputs.deploymentSasToken]"
+        },
+        "storageAccountKey": {
+            "type": "string",
+            "value": "[listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2019-06-01').keys[0].value]"
+            // Note: we have to do this because of ordering issues with the listKeys() function in arm templates
+            // https://bmoore-msft.blog/2020/07/26/resource-not-found-dependson-is-not-working/
+        }
+    }
+  }

--- a/frontend/src/components/UpdateSettings.vue
+++ b/frontend/src/components/UpdateSettings.vue
@@ -1,5 +1,5 @@
 <template>
-    <h1 class="title">Settings</h1><p>Release 1.2-preview, September 2023</p>
+    <h1 class="title">Settings</h1><p>Release 1.3-preview, November 2023</p>
     <hr />
     <div class="field">
         <label class="label">Timezone</label>

--- a/mainTemplate.json
+++ b/mainTemplate.json
@@ -20,17 +20,28 @@
             "location": "[resourceGroup().location]"
         },
         {
-            "type": "Microsoft.Storage/storageAccounts",
-            "apiVersion": "2021-02-01",
-            "name": "[variables('storageAccountName')]",
-            "sku": {
-                "name": "Standard_LRS"
-            },
-            "kind": "StorageV2",
-            "location": "[resourceGroup().location]",
+            "type": "Microsoft.Resources/deployments",
+            "apiVersion": "2022-09-01",
+            "name": "storageDeployment",
             "properties": {
-                "allowBlobPublicAccess": false,
-                "minimumTlsVersion": "TLS1_2"
+                "mode": "Incremental",
+                "templateLink": {
+                    "uri": "https://raw.githubusercontent.com/sg3-141-592/AzStartStop/main/copyDeployment.json"
+                },
+                "parameters": {
+                    "storageAccountName": {
+                        "value": "[variables('storageAccountName')]"
+                    },
+                    "storageAccountContainer": {
+                        "value": "deployment"
+                    },
+                    "downloadUrl": {
+                        "value": "https://startstopvmresources.compactcloud.co.uk/releases/az-start-stop-latest.squashfs"
+                    },
+                    "targetBlobFilename": {
+                        "value": "az-start-stop-latest.squashfs"
+                    }
+                }
             }
         },
         {
@@ -38,7 +49,7 @@
             "apiVersion": "2022-05-01",
             "name": "[concat(variables('storageAccountName'), '/default/data')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+                "[resourceId('Microsoft.Resources/deployments', 'storageDeployment')]"
             ],
             "properties": {
                 "immutableStorageWithVersioning": {
@@ -54,7 +65,7 @@
             "apiVersion": "2022-09-01",
             "name": "[concat(variables('storageAccountName'), '/default')]",
             "dependsOn": [
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+                "[resourceId('Microsoft.Resources/deployments', 'storageDeployment')]"
             ]
         },
         {
@@ -109,7 +120,7 @@
             },
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.Resources/deployments', 'storageDeployment')]",
                 "[resourceId('Microsoft.Insights/components', variables('applicationInsightsName'))]",
                 "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('userAssignedIdentityName'))]"
             ],
@@ -125,7 +136,7 @@
                         },
                         {
                             "name": "AzureWebJobsStorage",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';EndpointSuffix=', environment().suffixes.storage, ';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';EndpointSuffix=', environment().suffixes.storage, ';AccountKey=',reference('storageDeployment').outputs['storageAccountKey'].value)]"
                         },
                         {
                             "name": "AzureWebJobsFeatureFlags",
@@ -133,7 +144,7 @@
                         },
                         {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
-                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';EndpointSuffix=', environment().suffixes.storage, ';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2019-06-01').keys[0].value)]"
+                            "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';EndpointSuffix=', environment().suffixes.storage, ';AccountKey=',reference('storageDeployment').outputs['storageAccountKey'].value)]"
                         },
                         {
                             "name": "WEBSITE_CONTENTSHARE",
@@ -153,7 +164,7 @@
                         },
                         {
                             "name": "WEBSITE_RUN_FROM_PACKAGE",
-                            "value": "https://startstopvmresources.compactcloud.co.uk/releases/az-start-stop-latest.squashfs"
+                            "value": "[reference('storageDeployment').outputs['deploymentSasToken'].value]"
                         },
                         {
                             "name": "AZURE_CLIENT_ID",


### PR DESCRIPTION
Currently the file for the `WEBSITE_RUN_FROM_PACKAGE` setting is hosted by me, and because this app needs to run on a regular schedule it's taking a lot of bandwidth (£11.45 a month, but that cost will scale linearly with more users).

This change adds a new ARM template that takes a copy of the deployment file, adds it to blob storage and generates a Sas token for the `WEBSITE_RUN_FROM_PACKAGE` function app setting. This means that users host their own deployment.

This change also adds a daily scheduled function `check_for_updates()` that keeps the App deployment up to date.

<img width="243" alt="image" src="https://github.com/sg3-141-592/AzStartStop/assets/5122866/0c2cd0c8-2b71-4719-acf9-02145f22fd28">
